### PR TITLE
style: FE-02-메인-히어로-및-ui-폴리싱

### DIFF
--- a/src/components/common/Navbar.jsx
+++ b/src/components/common/Navbar.jsx
@@ -56,7 +56,7 @@ function Navbar() {
       <div className="navbar__inner">
         <NavLink to="/" className="navbar__logo">
           <span className="navbar__logo-prefix">&gt;</span>
-          <span className="navbar__logo-text">HackHub</span>
+          <span className="navbar__logo-text">DAKER</span>
           <span className="navbar__logo-cursor" />
         </NavLink>
 

--- a/src/index.css
+++ b/src/index.css
@@ -399,10 +399,7 @@ h2 {
 .main-banner {
   width: 100vw;
   margin-left: calc(-50vw + 50%);
-  background:
-    radial-gradient(circle at 15% 58%, rgba(63, 127, 232, 0.26), transparent 30%),
-    radial-gradient(circle at 22% 82%, rgba(91, 147, 240, 0.14), transparent 24%),
-    linear-gradient(180deg, #151515 0%, #141414 100%);
+  background: linear-gradient(180deg, #151515 0%, #141414 100%);
   min-height: 700px;
   position: relative;
   overflow: hidden;
@@ -422,18 +419,12 @@ h2 {
 .main-banner::after {
   content: '';
   position: absolute;
-  left: -8%;
-  bottom: -20%;
-  width: 44%;
-  height: 78%;
-  background: radial-gradient(
-    circle at center,
-    rgba(15, 199, 154, 0.24) 0%,
-    rgba(15, 199, 154, 0.12) 26%,
-    rgba(15, 199, 154, 0.04) 48%,
-    transparent 74%
-  );
-  filter: blur(28px);
+  inset: 0;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.01), rgba(255, 255, 255, 0)),
+    radial-gradient(circle at 18% 62%, rgba(63, 127, 232, 0.16), transparent 20%),
+    radial-gradient(circle at 74% 42%, rgba(63, 127, 232, 0.14), transparent 18%);
+  pointer-events: none;
 }
 
 .main-banner__content {
@@ -441,7 +432,7 @@ h2 {
   margin: 0 auto;
   padding: 78px 0 66px;
   display: grid;
-  grid-template-columns: minmax(0, 1.1fr) minmax(320px, 0.9fr);
+  grid-template-columns: minmax(0, 0.9fr) minmax(320px, 0.95fr);
   gap: 56px;
   align-items: center;
   position: relative;
@@ -449,7 +440,26 @@ h2 {
 }
 
 .main-banner__left {
+  position: relative;
+  z-index: 2;
   color: #ffffff;
+  max-width: 520px;
+}
+
+.main-banner__left::before {
+  content: '';
+  position: absolute;
+  left: -18%;
+  top: -8%;
+  width: 78%;
+  height: 138%;
+  background:
+    radial-gradient(ellipse at 38% 18%, rgba(95, 160, 255, 0.16), transparent 26%),
+    radial-gradient(ellipse at 34% 46%, rgba(72, 125, 232, 0.2), transparent 36%),
+    radial-gradient(ellipse at 28% 86%, rgba(63, 127, 232, 0.18), transparent 28%);
+  filter: blur(18px);
+  pointer-events: none;
+  z-index: -1;
 }
 
 .banner-label {
@@ -540,44 +550,228 @@ h2 {
   text-transform: uppercase;
 }
 
-.code-window {
-  border-radius: 20px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-top: 4px solid #3f7fe8;
-  background: rgba(255, 255, 255, 0.045);
-  padding: 28px 28px 30px;
-  overflow: hidden;
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
-}
-
-.code-window__header {
+.main-banner__brand {
+  position: relative;
+  min-height: 430px;
   display: flex;
-  gap: 10px;
-  margin-bottom: 22px;
+  align-items: center;
+  justify-content: center;
+  perspective: 1600px;
 }
 
-.code-window__header span {
-  width: 14px;
-  height: 14px;
-  border-radius: 50%;
-  background: rgba(255, 255, 255, 0.14);
+.brand-wordmark__ambient {
+  position: absolute;
+  inset: 14% 6% 8%;
+  background:
+    radial-gradient(circle at 34% 36%, rgba(107, 156, 255, 0.18), transparent 22%),
+    radial-gradient(circle at 72% 58%, rgba(63, 127, 232, 0.22), transparent 28%),
+    radial-gradient(circle at 52% 82%, rgba(63, 127, 232, 0.12), transparent 24%);
+  filter: blur(38px);
+  opacity: 0.95;
+  pointer-events: none;
+  animation: brandAmbientPulse 6.4s ease-in-out infinite;
 }
 
-.code-window__body {
+.brand-wordmark {
+  position: relative;
   display: flex;
   flex-direction: column;
-  gap: 9px;
-  color: rgba(255, 255, 255, 0.34);
-  font-size: 0.88rem;
-  line-height: 1.55;
-  font-family: 'JetBrains Mono', ui-monospace, monospace;
-  white-space: pre-wrap;
+  align-items: center;
+  gap: clamp(-0.7rem, -0.4vw, -0.24rem);
+  transform-style: preserve-3d;
+  transform:
+    rotateX(var(--brand-rotate-x, 0deg))
+    rotateY(var(--brand-rotate-y, 0deg))
+    translateZ(0);
+  transition: transform 0.28s ease;
+  animation:
+    brandWordmarkEntrance 1.1s cubic-bezier(0.2, 0.85, 0.2, 1) both,
+    brandWordmarkFloat 7.2s ease-in-out 1.1s infinite;
 }
 
-.code-comment { color: rgba(255, 255, 255, 0.24); }
-.code-keyword { color: var(--primary); }
-.code-function { color: #79c0ff; }
-.code-string { color: #f6b65e; }
+.brand-wordmark::after {
+  content: '';
+  position: absolute;
+  left: 16%;
+  right: 16%;
+  bottom: -10%;
+  height: 18%;
+  background: radial-gradient(circle, rgba(78, 127, 232, 0.34), transparent 68%);
+  filter: blur(18px);
+  opacity: 0.9;
+  transform: translateZ(-40px);
+  pointer-events: none;
+}
+
+.brand-wordmark__row {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: clamp(0.08rem, 0.35vw, 0.2rem);
+  line-height: 0.82;
+}
+
+.brand-wordmark__glyph {
+  display: inline-block;
+  font-size: clamp(3.2rem, 7vw, 6rem);
+  font-weight: 900;
+  line-height: 0.92;
+  letter-spacing: -0.08em;
+  text-transform: uppercase;
+  user-select: none;
+  transform:
+    translate3d(
+      calc((var(--layer-index) - 1) * 54px + (var(--row-index) - 2) * 14px),
+      calc((2 - var(--row-index)) * 24px + (1 - var(--layer-index)) * 18px),
+      0
+    )
+    rotateZ(calc((var(--layer-index) - 1) * 5deg + (var(--row-index) - 2) * 1.6deg))
+    scale(0.86);
+  transform-origin: center;
+  opacity: 0;
+  filter: blur(7px);
+  animation: brandGlyphAssemble 1.28s cubic-bezier(0.2, 0.85, 0.2, 1) forwards;
+  animation-delay: calc(var(--row-index) * 0.06s + var(--layer-index) * 0.08s);
+}
+
+.brand-wordmark__glyph--face {
+  color: #f6f8ff;
+  text-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.82),
+    0 0 28px rgba(118, 167, 255, 0.24);
+}
+
+.brand-wordmark__glyph--mid {
+  color: #3567c2;
+}
+
+.brand-wordmark__glyph--deep {
+  color: #1a3770;
+  opacity: 0.9;
+}
+
+@keyframes brandWordmarkEntrance {
+  0% {
+    opacity: 0;
+    transform:
+      scale(1.08)
+      rotateX(calc(var(--brand-rotate-x, 0deg) + 4deg))
+      rotateY(calc(var(--brand-rotate-y, 0deg) - 6deg));
+    filter: blur(12px);
+  }
+  100% {
+    opacity: 1;
+    transform:
+      scale(1)
+      rotateX(var(--brand-rotate-x, 0deg))
+      rotateY(var(--brand-rotate-y, 0deg));
+    filter: blur(0);
+  }
+}
+
+@keyframes brandGlyphAssemble {
+  0% {
+    transform:
+      translate3d(
+        calc((var(--layer-index) - 1) * 54px + (var(--row-index) - 2) * 14px),
+        calc((2 - var(--row-index)) * 24px + (1 - var(--layer-index)) * 18px),
+        0
+      )
+      rotateZ(calc((var(--layer-index) - 1) * 5deg + (var(--row-index) - 2) * 1.6deg))
+      scale(0.86);
+    opacity: 0;
+    filter: blur(7px);
+  }
+  55% {
+    opacity: 1;
+  }
+  100% {
+    transform: translate3d(0, 0, 0) rotateZ(0deg) scale(1);
+    opacity: 1;
+    filter: blur(0);
+  }
+}
+
+@keyframes brandWordmarkFloat {
+  0%,
+  100% {
+    transform:
+      rotateX(var(--brand-rotate-x, 0deg))
+      rotateY(var(--brand-rotate-y, 0deg))
+      translateY(0);
+  }
+  50% {
+    transform:
+      rotateX(calc(var(--brand-rotate-x, 0deg) + 0.8deg))
+      rotateY(calc(var(--brand-rotate-y, 0deg) - 0.8deg))
+      translateY(-6px);
+  }
+}
+
+@keyframes brandAmbientPulse {
+  0%,
+  100% {
+    transform: scale(1) translateY(0);
+    opacity: 0.88;
+  }
+  50% {
+    transform: scale(1.04) translateY(-8px);
+    opacity: 1;
+  }
+}
+
+@keyframes nebulaDriftOne {
+  0%, 100% { transform: translate(0, 0) scale(1); }
+  50% { transform: translate(16px, -12px) scale(1.06); }
+}
+
+@keyframes nebulaDriftTwo {
+  0%, 100% { transform: translate(0, 0) scale(1); }
+  50% { transform: translate(-18px, 10px) scale(1.08); }
+}
+
+@keyframes nebulaDriftThree {
+  0%, 100% { transform: translate(0, 0) scale(1); }
+  50% { transform: translate(12px, -8px) scale(1.04); }
+}
+
+@keyframes sphereFloatOne {
+  0%, 100% {
+    transform: translateY(0) translateX(0) rotate(-12deg);
+    border-radius: 42% 58% 63% 37% / 38% 41% 59% 62%;
+  }
+  35% {
+    transform: translateY(-10px) translateX(-8px) rotate(-8deg);
+    border-radius: 48% 52% 58% 42% / 34% 46% 54% 66%;
+  }
+  70% {
+    transform: translateY(7px) translateX(4px) rotate(-15deg);
+    border-radius: 38% 62% 52% 48% / 42% 36% 64% 58%;
+  }
+}
+
+@keyframes sphereFloatTwo {
+  0%, 100% {
+    transform: translateY(0) translateX(0) rotate(16deg);
+    border-radius: 44% 56% 60% 40% / 36% 44% 56% 64%;
+  }
+  50% {
+    transform: translateY(10px) translateX(12px) rotate(22deg);
+    border-radius: 57% 43% 52% 48% / 42% 52% 48% 58%;
+  }
+}
+
+@keyframes sphereFloatThree {
+  0%, 100% {
+    transform: translateY(0) translateX(0) rotate(20deg);
+    border-radius: 46% 54% 62% 38% / 40% 36% 64% 60%;
+  }
+  50% {
+    transform: translateY(-10px) translateX(10px) rotate(28deg);
+    border-radius: 60% 40% 48% 52% / 44% 58% 42% 56%;
+  }
+}
 
 .main-hero {
   padding: 80px 0 100px;
@@ -3179,6 +3373,10 @@ h2 {
   .main-banner__content,
   .detail-grid {
     grid-template-columns: 1fr;
+  }
+
+  .main-banner__brand {
+    min-height: 260px;
   }
 
   .hero-editorial {

--- a/src/pages/MainPage.jsx
+++ b/src/pages/MainPage.jsx
@@ -15,6 +15,7 @@ function MainPage() {
   const totalLength = cumulativeLengths[cumulativeLengths.length - 1]
   const [displayedLength, setDisplayedLength] = useState(0)
   const [isDeleting, setIsDeleting] = useState(false)
+  const [brandTilt, setBrandTilt] = useState({ x: 0, y: 0 })
   const [visibleHackathons, setVisibleHackathons] = useState(
     hackathons.filter((item) => item.status === 'open'),
   )
@@ -102,9 +103,28 @@ function MainPage() {
     }
   }, [])
 
+  function handleBannerMouseMove(event) {
+    const bounds = event.currentTarget.getBoundingClientRect()
+    const ratioX = (event.clientX - bounds.left) / bounds.width - 0.5
+    const ratioY = (event.clientY - bounds.top) / bounds.height - 0.5
+
+    setBrandTilt({
+      x: ratioY * -8,
+      y: ratioX * 10,
+    })
+  }
+
+  function handleBannerMouseLeave() {
+    setBrandTilt({ x: 0, y: 0 })
+  }
+
   return (
     <section className="page-section">
-      <div className="main-banner">
+      <div
+        className="main-banner"
+        onMouseMove={handleBannerMouseMove}
+        onMouseLeave={handleBannerMouseLeave}
+      >
         <div className="main-banner__content">
           <div className="main-banner__left">
             <p className="banner-label">// HACKATHON PLATFORM v2.0</p>
@@ -146,31 +166,42 @@ function MainPage() {
               </div>
             </div>
           </div>
-
-          <div className="code-window">
-            <div className="code-window__header">
-              <span />
-              <span />
-              <span />
+          <div
+            className="main-banner__brand"
+            style={{
+              '--brand-rotate-x': `${brandTilt.x}deg`,
+              '--brand-rotate-y': `${brandTilt.y}deg`,
+            }}
+          >
+            <div className="brand-wordmark__ambient" />
+            <div className="brand-wordmark" aria-hidden="true">
+              {['D', 'A', 'K', 'E', 'R'].map((letter, rowIndex) => (
+                <span
+                  key={`${letter}-${rowIndex}`}
+                  className="brand-wordmark__row"
+                  style={{ '--row-index': rowIndex }}
+                >
+                  <span
+                    className="brand-wordmark__glyph brand-wordmark__glyph--deep"
+                    style={{ '--layer-index': 0 }}
+                  >
+                    {letter}
+                  </span>
+                  <span
+                    className="brand-wordmark__glyph brand-wordmark__glyph--mid"
+                    style={{ '--layer-index': 1 }}
+                  >
+                    {letter}
+                  </span>
+                  <span
+                    className="brand-wordmark__glyph brand-wordmark__glyph--face"
+                    style={{ '--layer-index': 2 }}
+                  >
+                    {letter}
+                  </span>
+                </span>
+              ))}
             </div>
-            <code className="code-window__body">
-              <span className="code-comment">// hackathon.config.ts</span>
-              <span>
-                <span className="code-keyword">export const</span>{' '}
-                <span className="code-function">config</span> = {'{'}
-              </span>
-              <span>  name: <span className="code-string">"AI Summit 2026"</span>,</span>
-              <span>  status: <span className="code-string">"open"</span>,</span>
-              <span>  prize: <span className="code-string">"₩3,000,000"</span>,</span>
-              <span>  tags: [<span className="code-string">"AI/ML"</span>, <span className="code-string">"Web"</span>],</span>
-              <span>  maxTeamSize: 4,</span>
-              <span>{'}'}</span>
-              <span />
-              <span>
-                <span className="code-keyword">await</span>{' '}
-                <span className="code-function">hackathon</span>.join(config)
-              </span>
-            </code>
           </div>
         </div>
       </div>


### PR DESCRIPTION
##  변경 내용 요약
- 메인 랜딩 화면과 주요 UI 요소의 시각적 완성도를 높이기 위해 브랜드 컬러, 인터랙션, 카드 레이아웃, hover 효과 등을 전반적으로 다듬었습니다.
- `/camp` 팀 상세 드로어 버튼 줄바꿈, 메인 히어로 영역, 에디토리얼 카드 등 자잘한 UI 이슈를 수정하고 브랜드 톤에 맞게 폴리싱했습니다.

##  상세 변경 내역
- `src/index.css`:
  - 브랜드 accent 컬러를 DAKER 블루 톤으로 정리
  - 메인 히어로 보드 높이/그라데이션/배경 glow 조정
  - `Build. Compete. Win.` 뒤 배경 그라데이션 재구성
  - 메인 하단 에디토리얼 카드 레이아웃/hover 효과/좌측 하이라이트 동작 개선
  - 메인 브랜드 오브젝트 실험 후, 현재 톤에 맞게 정리
  - `/camp` 팀 상세 드로어 하단 버튼 줄바꿈 수정
- `src/pages/MainPage.jsx`:
  - 메인 랜딩 히어로 인터랙션 및 브랜드 노출 구조 보정
  - 하단 소개 섹션을 비대칭 에디토리얼 카드 구조로 정리
- `src/pages/CampPage.jsx`:
  - 팀 상세 보기 드로어 UX 확인 및 관련 UI polish 반영

##  테스트 방법
1. `npm install`
2. `npm run dev`
3. 브라우저에서 `http://localhost:5173` 접속
4. 메인 화면에서
   - 히어로 영역 레이아웃
   - 브랜드 컬러 적용 상태
   - 하단 에디토리얼 카드 hover 효과
   - 상하 여백 및 그라데이션 노출 상태 확인
5. `/camp` 진입 후 팀 카드 클릭
6. 팀 상세 드로어 하단 `닫기`, `합류 신청` 버튼 줄바꿈 없이 표시되는지 확인


##  기타 참고 사항
- 이번 PR은 기능 추가보다 UI 폴리싱과 시각적 완성도 개선에 초점을 맞췄습니다.
- 메인 랜딩 영역은 여러 시안을 거쳐 현재 브랜드 톤에 맞는 버전으로 정리했습니다.
- 백엔드 API 연동 로직은 건드리지 않고 `Daker-front`만 수정했습니다.
