### PR TITLE
feat: 팀 삭제 정책 반영 및 해커톤 상세 팀/일정 탭 개선

### DIFF
--- a/src/api/teams.js
+++ b/src/api/teams.js
@@ -7,6 +7,13 @@ import {
 } from './client.js'
 import { getAccessToken } from '../lib/auth.js'
 
+// 진행 중인 해커톤(=closed: 라벨 "진행중") 팀은 삭제가 불가능합니다.
+// 참고로 이 코드베이스의 상태 라벨(api/hackathons.js)은 다음과 같습니다:
+//   upcoming → 오픈예정, open → 모집중, closed → 진행중, ended → 종료
+export function isHackathonDeletionBlocked(status) {
+  return status === 'closed'
+}
+
 function normalizeTeam(item) {
   const positionDetails = Array.isArray(item.positions)
     ? item.positions
@@ -34,6 +41,11 @@ function normalizeTeam(item) {
       item.hackathonName ??
       item.hackathon?.title ??
       (item.hackathonId ? `해커톤 #${item.hackathonId}` : '해커톤 미정'),
+    hackathonStatus:
+      item.hackathonStatus ?? item.hackathon?.status ?? null,
+    hackathonStatusLabel:
+      item.hackathonStatusLabel ?? item.hackathon?.statusLabel ?? null,
+    isDeleted: item.isDeleted === true,
     positions: positionDetails.map((position) => position.positionName),
     positionDetails,
     isOpen:

--- a/src/components/common/Toast.jsx
+++ b/src/components/common/Toast.jsx
@@ -1,0 +1,19 @@
+import { useEffect } from 'react'
+
+function Toast({ toast, onDismiss, durationMs = 2600 }) {
+  useEffect(() => {
+    if (!toast) return undefined
+    const timer = window.setTimeout(() => onDismiss(), durationMs)
+    return () => window.clearTimeout(timer)
+  }, [toast, onDismiss, durationMs])
+
+  if (!toast) return null
+
+  return (
+    <div className={`admin-toast admin-toast--${toast.type ?? 'success'}`} role="status">
+      {toast.message}
+    </div>
+  )
+}
+
+export default Toast

--- a/src/index.css
+++ b/src/index.css
@@ -2204,7 +2204,12 @@ h2 {
 .detail-section__content {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 32px;
+}
+
+.detail-section__content > .detail-block + .detail-block {
+  padding-top: 32px;
+  border-top: 1px solid #eceff1;
 }
 
 .detail-list-row {
@@ -2236,27 +2241,63 @@ h2 {
   color: #4b5563;
 }
 
-.detail-chat-join {
-  margin-top: 8px;
+/* Sidebar chat card */
+.sidebar-card--chat {
+  background: linear-gradient(140deg, #f5f9ff 0%, #ffffff 60%);
+  border-color: #dbeafe;
 }
 
-.detail-chat-join__row {
+.sidebar-chat__head {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 12px;
-  flex-wrap: wrap;
+  margin-bottom: 16px;
 }
 
-.detail-chat-join__msg {
-  font-size: 0.9rem;
+.sidebar-chat__head h3 {
+  margin: 0 0 4px;
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: #111827;
+  letter-spacing: -0.01em;
+  text-transform: none;
 }
 
-.detail-chat-join__msg--ok {
-  color: #22c55e;
+.sidebar-chat__icon {
+  flex-shrink: 0;
+  width: 36px;
+  height: 36px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 10px;
+  background: #3f7fe8;
+  color: #ffffff;
 }
 
-.detail-chat-join__msg--err {
-  color: #ef4444;
+.sidebar-chat__desc {
+  margin: 0;
+  font-size: 0.78rem;
+  color: #6b7280;
+  line-height: 1.45;
+}
+
+.sidebar-chat__btn {
+  width: 100%;
+  justify-content: center;
+}
+
+.sidebar-chat__msg {
+  margin: 10px 0 0;
+  font-size: 0.82rem;
+}
+
+.sidebar-chat__msg--ok {
+  color: #16a34a;
+}
+
+.sidebar-chat__msg--err {
+  color: #dc2626;
 }
 
 .schedule-legend {
@@ -2303,6 +2344,183 @@ h2 {
   gap: 20px;
 }
 
+/* ── Schedule Timeline (단일 타임라인) ───────────── */
+.schedule-timeline {
+  list-style: none;
+  margin: 0;
+  padding: 8px 0 0;
+  position: relative;
+}
+
+.schedule-timeline__item {
+  position: relative;
+  display: grid;
+  grid-template-columns: 32px 1fr;
+  gap: 18px;
+  padding: 0 0 28px;
+}
+
+.schedule-timeline__item:last-child {
+  padding-bottom: 4px;
+}
+
+/* 세로 연결선 */
+.schedule-timeline__item::before {
+  content: "";
+  position: absolute;
+  left: 15px;
+  top: 28px;
+  bottom: 0;
+  width: 2px;
+  background: #e5e7eb;
+}
+
+.schedule-timeline__item:last-child::before {
+  display: none;
+}
+
+.schedule-timeline__item--done::before {
+  background: #3f7fe8;
+}
+
+.schedule-timeline__item--current::before {
+  background: linear-gradient(180deg, #3f7fe8 0%, #e5e7eb 100%);
+}
+
+.schedule-timeline__marker {
+  position: relative;
+  z-index: 1;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+}
+
+.schedule-timeline__dot {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 2px solid #d1d5db;
+  background: #ffffff;
+  color: #ffffff;
+  flex-shrink: 0;
+  margin-top: 4px;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.schedule-timeline__item--done .schedule-timeline__dot {
+  background: #3f7fe8;
+  border-color: #3f7fe8;
+}
+
+.schedule-timeline__item--current .schedule-timeline__dot {
+  background: #ffffff;
+  border-color: #3f7fe8;
+  border-width: 3px;
+  box-shadow: 0 0 0 0 rgba(63, 127, 232, 0.55);
+  animation: schedule-pulse 1.8s ease-out infinite;
+}
+
+.schedule-timeline__item--current .schedule-timeline__dot::after {
+  content: "";
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #3f7fe8;
+}
+
+@keyframes schedule-pulse {
+  0% {
+    box-shadow: 0 0 0 0 rgba(63, 127, 232, 0.55);
+  }
+  70% {
+    box-shadow: 0 0 0 14px rgba(63, 127, 232, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(63, 127, 232, 0);
+  }
+}
+
+.schedule-timeline__content {
+  min-width: 0;
+  padding-top: 2px;
+}
+
+.schedule-timeline__head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-bottom: 6px;
+}
+
+.schedule-timeline__date {
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 0.82rem;
+  font-weight: 800;
+  color: #6b7280;
+  letter-spacing: 0.01em;
+}
+
+.schedule-timeline__section {
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: #6b7280;
+  background: #f3f4f6;
+  padding: 3px 8px;
+  border-radius: 999px;
+  letter-spacing: 0.02em;
+}
+
+.schedule-timeline__label {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+  color: #374151;
+  letter-spacing: -0.01em;
+  line-height: 1.4;
+}
+
+.schedule-timeline__item--done .schedule-timeline__label {
+  color: #6b7280;
+  text-decoration: line-through;
+  text-decoration-color: #d1d5db;
+}
+
+.schedule-timeline__item--current .schedule-timeline__label {
+  color: #111827;
+  font-size: 1.08rem;
+}
+
+.schedule-timeline__item--upcoming .schedule-timeline__label {
+  color: #4b5563;
+}
+
+.schedule-timeline__pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 8px;
+  padding: 4px 12px;
+  border-radius: 999px;
+  background: #3f7fe8;
+  color: #ffffff;
+  font-size: 0.74rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  animation: schedule-pill-fade 1.8s ease-in-out infinite;
+}
+
+@keyframes schedule-pill-fade {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.55; }
+}
+
 .schedule-card {
   border: 1px solid #e5e7eb;
   border-radius: 18px;
@@ -2316,6 +2534,32 @@ h2 {
   justify-content: space-between;
   gap: 18px;
   padding: 24px 28px;
+  width: 100%;
+  background: transparent;
+  border: 0;
+  text-align: left;
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+  transition: background 0.15s ease;
+}
+
+.schedule-card__head:hover {
+  background: #f9fafb;
+}
+
+.schedule-card__head:focus-visible {
+  outline: 2px solid #3f7fe8;
+  outline-offset: -2px;
+  border-radius: 12px;
+}
+
+.schedule-card__chevron {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: #6b7280;
+  margin-left: 4px;
 }
 
 .schedule-card__title-wrap {
@@ -2337,10 +2581,6 @@ h2 {
   font-size: 0.96rem;
   font-weight: 800;
   font-family: "JetBrains Mono", ui-monospace, monospace;
-}
-
-.schedule-card__chevron {
-  font-size: 1rem;
 }
 
 .schedule-card__body {
@@ -2979,6 +3219,27 @@ h2 {
   grid-template-columns: minmax(0, 1fr) minmax(0, 1.2fr) 220px;
   align-items: center;
   gap: 16px;
+}
+
+.mypage-team-item--deleted,
+.mypage-timeline-item--deleted {
+  opacity: 0.55;
+  pointer-events: none;
+  filter: grayscale(0.3);
+}
+
+.mypage-deleted-badge {
+  display: inline-flex;
+  align-items: center;
+  margin-left: 8px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: #f3f4f6;
+  color: #6b7280;
+  border: 1px solid #d1d5db;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
 }
 
 .mypage-team-item--primary {
@@ -4922,6 +5183,13 @@ h2 {
   line-height: 1.6;
 }
 
+.team-state-card__description--lg {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #374151;
+  line-height: 1.5;
+}
+
 .team-state-actions {
   display: flex;
   flex-wrap: wrap;
@@ -5002,6 +5270,14 @@ h2 {
   background: #ffffff;
   color: #ff4d4f;
   border-color: #ff4d4f;
+}
+
+.team-danger-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+  background: #f3f4f6;
+  color: #9ca3af;
+  border-color: #d1d5db;
 }
 
 .my-team-panel {
@@ -5331,6 +5607,16 @@ h2 {
   background: #fafafa;
 }
 
+.mypage-modal__footer--spread {
+  justify-content: space-between;
+  align-items: center;
+}
+
+.mypage-modal__footer-actions {
+  display: flex;
+  gap: 8px;
+}
+
 .mypage-modal__empty {
   text-align: center;
   color: #9ca3af;
@@ -5652,6 +5938,261 @@ h2 {
   align-items: center;
   gap: 10px;
   flex-wrap: wrap;
+}
+
+/* ── Team Select Modal (기존 팀으로 참가) ───────────── */
+.team-select-modal {
+  width: min(640px, calc(100vw - 32px));
+  max-height: calc(100vh - 64px);
+  background: #ffffff;
+  border-radius: 20px;
+  box-shadow: 0 30px 80px rgba(15, 23, 42, 0.22);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.team-select-modal__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 28px 32px 20px;
+  border-bottom: 1px solid #f3f4f6;
+}
+
+.team-select-modal__heading .eyebrow {
+  margin: 0 0 6px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #3f7fe8;
+}
+
+.team-select-modal__heading h2 {
+  margin: 0 0 8px;
+  font-size: 1.5rem;
+  letter-spacing: -0.03em;
+  color: #111827;
+}
+
+.team-select-modal__subtitle {
+  margin: 0;
+  color: #6b7280;
+  font-size: 0.92rem;
+  line-height: 1.55;
+}
+
+.team-select-modal__close {
+  flex-shrink: 0;
+  width: 36px;
+  height: 36px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 10px;
+  border: 1px solid #e5e7eb;
+  background: #ffffff;
+  color: #6b7280;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+
+.team-select-modal__close:hover {
+  background: #f3f4f6;
+  color: #111827;
+  border-color: #d1d5db;
+}
+
+.team-select-modal__body {
+  padding: 20px 32px 24px;
+  overflow-y: auto;
+  flex: 1 1 auto;
+}
+
+.team-select-modal__error {
+  margin: 14px 0 0;
+  color: #b91c1c;
+  font-size: 0.88rem;
+  font-weight: 600;
+}
+
+.team-select-modal__footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  padding: 18px 32px 24px;
+  border-top: 1px solid #f3f4f6;
+  background: #fafafa;
+}
+
+/* Team select cards */
+.team-select-card {
+  display: flex;
+  align-items: stretch;
+  gap: 14px;
+  padding: 18px 20px;
+  border-radius: 16px;
+  border: 1.5px solid #e5e7eb;
+  background: #ffffff;
+  cursor: pointer;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease, background 0.15s ease, transform 0.1s ease;
+}
+
+.team-select-card:hover {
+  border-color: #c7d2fe;
+  background: #fafbff;
+  transform: translateY(-1px);
+}
+
+.team-select-card--active {
+  border-color: #3f7fe8;
+  background: #f5f9ff;
+  box-shadow: 0 0 0 4px rgba(63, 127, 232, 0.12);
+}
+
+.team-select-card input[type="radio"] {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.team-select-card__body {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+}
+
+.team-select-card__head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.team-select-card__name {
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: #111827;
+  letter-spacing: -0.01em;
+}
+
+.team-select-card__desc {
+  margin: 0;
+  font-size: 0.88rem;
+  color: #6b7280;
+  line-height: 1.5;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.team-select-card__meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 2px;
+}
+
+.team-select-card__count {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: #f3f4f6;
+  color: #4b5563;
+  font-size: 0.78rem;
+  font-weight: 600;
+}
+
+.tag-chip--ghost {
+  background: transparent;
+  color: #6b7280;
+  border: 1px dashed #d1d5db;
+}
+
+.team-select-card__check {
+  flex-shrink: 0;
+  width: 28px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  border: 2px solid #d1d5db;
+  background: #ffffff;
+  color: #ffffff;
+  align-self: center;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.team-select-card--active .team-select-card__check {
+  background: #3f7fe8;
+  border-color: #3f7fe8;
+}
+
+/* Empty state */
+.team-select-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: 36px 20px 20px;
+}
+
+.team-select-empty__icon {
+  width: 72px;
+  height: 72px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: #f3f4f6;
+  color: #9ca3af;
+  margin-bottom: 18px;
+}
+
+.team-select-empty__title {
+  margin: 0 0 8px;
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: #111827;
+  letter-spacing: -0.01em;
+}
+
+.team-select-empty__desc {
+  margin: 0 0 22px;
+  color: #6b7280;
+  font-size: 0.92rem;
+  line-height: 1.55;
+}
+
+.team-select-empty__actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+@media (max-width: 600px) {
+  .team-select-modal__header,
+  .team-select-modal__body,
+  .team-select-modal__footer {
+    padding-left: 22px;
+    padding-right: 22px;
+  }
+  .team-select-modal__footer {
+    flex-direction: column-reverse;
+  }
+  .team-select-modal__footer button {
+    width: 100%;
+  }
 }
 
 .submit-guide-card {

--- a/src/pages/CampPage.jsx
+++ b/src/pages/CampPage.jsx
@@ -7,10 +7,12 @@ import {
   fetchMyTeams,
   fetchTeamDetail,
   fetchTeams,
+  isHackathonDeletionBlocked,
   updateTeam,
 } from "../api/teams.js";
 import { getStoredUser } from "../lib/auth.js";
 import Pagination from "../components/common/Pagination.jsx";
+import Toast from "../components/common/Toast.jsx";
 
 const PAGE_SIZE = 6
 
@@ -55,6 +57,7 @@ function CampPage() {
   const [editMessage, setEditMessage] = useState("");
   const [isSavingEdit, setIsSavingEdit] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [toast, setToast] = useState(null);
 
   useEffect(() => {
     let isMounted = true;
@@ -494,6 +497,15 @@ function CampPage() {
                   <button
                     type="button"
                     className="team-danger-button"
+                    disabled={
+                      isDeleting ||
+                      isHackathonDeletionBlocked(selectedTeam.hackathonStatus)
+                    }
+                    title={
+                      isHackathonDeletionBlocked(selectedTeam.hackathonStatus)
+                        ? "진행 중인 해커톤의 팀은 삭제할 수 없습니다."
+                        : undefined
+                    }
                     onClick={async () => {
                       try {
                         setIsDeleting(true);
@@ -511,8 +523,14 @@ function CampPage() {
                           ),
                         );
                         setSelectedTeam(null);
-                      } catch {
-                        setTeamDetailMessage("팀 삭제에 실패했습니다.");
+                        setToast({ type: "success", message: "팀이 삭제되었습니다." });
+                      } catch (err) {
+                        // 진행 중 해커톤이면 백엔드가 400 + data.message 로 사유를 내려줍니다.
+                        const message =
+                          err?.status === 400 && err?.message
+                            ? err.message
+                            : "팀 삭제에 실패했습니다.";
+                        setToast({ type: "error", message });
                       } finally {
                         setIsDeleting(false);
                       }
@@ -811,6 +829,8 @@ function CampPage() {
           </aside>
         </div>
       ) : null}
+
+      <Toast toast={toast} onDismiss={() => setToast(null)} />
     </section>
   );
 }

--- a/src/pages/HackathonDetailPage.jsx
+++ b/src/pages/HackathonDetailPage.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { AlertTriangle, Clock, Handshake, Info, Lock, Trophy, Users } from "lucide-react";
+import { Check, Clock, Handshake, Lock, MessageCircle, Trophy, Users, X } from "lucide-react";
 import { Link, useNavigate, useParams, useSearchParams } from "react-router-dom";
 import {
   cancelRegistration,
@@ -18,11 +18,13 @@ import {
   fetchMyTeams,
   fetchTeamApplications,
   fetchTeamDetail,
+  isHackathonDeletionBlocked,
   updateTeam,
 } from "../api/teams.js";
 import { getStoredUser } from "../lib/auth.js";
 import { joinChat } from "../api/chat.js";
 import { openChatDrawer } from "../lib/chat-events.js";
+import Toast from "../components/common/Toast.jsx";
 
 const detailTabs = [
   { key: "overview", label: "개요" },
@@ -38,6 +40,14 @@ function createEmptyPosition() {
     positionName: "",
     requiredCount: "1",
   };
+}
+
+// /teams/me 응답에 hackathonId가 없는 경우 hackathonName(=hackathonTitle)으로 폴백
+function isTeamEligibleForHackathon(team, hackathonId, hackathonTitle) {
+  if (team.hackathonId) return String(team.hackathonId) === String(hackathonId);
+  // hackathonId 없으면 이름으로 비교, 이름도 없으면(미배정 팀) eligible
+  if (!team.hackathonName || team.hackathonName === '해커톤 미정') return true;
+  return team.hackathonName === hackathonTitle;
 }
 
 function getSubmitState(isRegistered, hasTeam, hackathonStatus) {
@@ -107,11 +117,11 @@ function HackathonDetailPage() {
   const [teamCreateError, setTeamCreateError] = useState(null);
   const [leaveTeamConfirmOpen, setLeaveTeamConfirmOpen] = useState(false);
   const [deleteTeamConfirmOpen, setDeleteTeamConfirmOpen] = useState(false);
+  const [toast, setToast] = useState(null);
   const [registerHereLoading, setRegisterHereLoading] = useState(false);
   const [selectedTeamForRegistration, setSelectedTeamForRegistration] = useState("");
   const [registerConfirmOpen, setRegisterConfirmOpen] = useState(false);
   const [teamCreateAutoRegister, setTeamCreateAutoRegister] = useState(false);
-  const [c2View, setC2View] = useState("choice"); // "choice" | "select"
   const currentUser = getStoredUser();
   const currentUserId = currentUser?.userId ?? null;
   const currentUserNickname = currentUser?.nickname ?? null;
@@ -204,21 +214,54 @@ function HackathonDetailPage() {
       setIsTeamCreateModalOpen(false);
 
       if (teamCreateAutoRegister && newTeam?.id) {
-        // A / B / C-1: 생성 후 바로 이 해커톤으로 신청
-        await registerHackathon(id, newTeam.id);
+        // 백엔드가 POST /teams (hackathonId 포함) 시점에 자동 등록까지 처리하므로
+        // 별도의 registerHackathon 호출은 생략 (중복 호출 시 409 "이미 합류 신청한 팀입니다.")
         await completeRegistration(newTeam.id, "팀을 생성하고 해커톤에 참가 신청했습니다.");
       } else {
         // C-2: 팀 목록 갱신 후 새 팀 선택 상태로
-        const freshMyTeams = await fetchMyTeams(id);
+        const freshMyTeams = await fetchMyTeams();
         setMyTeams(freshMyTeams);
         if (newTeam?.id) {
           setSelectedTeamForRegistration(String(newTeam.id));
         }
+        // 팀 탭의 "참가 팀 현황"도 새 팀이 즉시 보이도록 갱신
+        await refreshParticipantTeams();
       }
-    } catch {
-      setTeamCreateError("팀 생성에 실패했습니다. 다시 시도해주세요.");
+    } catch (err) {
+      // 백엔드가 400/409 에러 메시지를 data.message 로 내려주므로 그대로 노출
+      const message = err?.message || "팀 생성에 실패했습니다. 다시 시도해주세요.";
+      setTeamCreateError(message);
+      // 모달이 이미 닫힌 뒤 실패한 경우엔 토스트로도 알림
+      if (!isTeamCreateModalOpen) {
+        setToast({ type: "error", message });
+      }
     } finally {
       setIsCreatingTeam(false);
+    }
+  }
+
+  async function handleChatJoin() {
+    if (chatJoined) {
+      openChatDrawer({ hackathonId: Number(id), refreshRooms: true });
+      return;
+    }
+    setChatJoining(true);
+    setChatJoinMessage("");
+    try {
+      await joinChat(id);
+      setChatJoined(true);
+      setChatJoinMessage("채팅방에 참가했습니다.");
+      openChatDrawer({ hackathonId: Number(id), refreshRooms: true });
+    } catch (err) {
+      if (err?.status === 409) {
+        setChatJoined(true);
+        setChatJoinMessage("이미 참가한 채팅방입니다.");
+        openChatDrawer({ hackathonId: Number(id), refreshRooms: true });
+      } else {
+        setChatJoinMessage("참가에 실패했습니다.");
+      }
+    } finally {
+      setChatJoining(false);
     }
   }
 
@@ -239,7 +282,7 @@ function HackathonDetailPage() {
 
   function resolveTeamStateFromList(freshMyTeams) {
     const eligibleTeams = freshMyTeams.filter(
-      t => !t.hackathonId || String(t.hackathonId) === String(id)
+      t => isTeamEligibleForHackathon(t, id, hackathon?.title)
     );
     if (eligibleTeams.length === 0) return "B";
     const leaderTeam = eligibleTeams.find(
@@ -255,7 +298,7 @@ function HackathonDetailPage() {
       setRegistrationStatus(null);
       setMyTeamDetail(null);
       setApplications([]);
-      const freshMyTeams = await fetchMyTeams(id);
+      const freshMyTeams = await fetchMyTeams();
       setMyTeams(freshMyTeams);
       const nextState = freshMyTeams.length === 0 ? "A" : resolveTeamStateFromList(freshMyTeams);
       setTeamState(nextState);
@@ -274,7 +317,7 @@ function HackathonDetailPage() {
     try {
       setIsDeletingTeam(true);
       await deleteTeam(myTeamDetail.id);
-      const freshMyTeams = await fetchMyTeams(id);
+      const freshMyTeams = await fetchMyTeams();
       setMyTeams(freshMyTeams);
       setMyTeamDetail(null);
       setApplications([]);
@@ -283,10 +326,15 @@ function HackathonDetailPage() {
       setTeamState(nextState);
       setSubmitState(getSubmitState(false, false, hackathon?.status));
       await refreshParticipantTeams();
-      setRegistrationMessage("팀이 삭제되었습니다.");
+      setToast({ type: "success", message: "팀이 삭제되었습니다." });
       setDeleteTeamConfirmOpen(false);
-    } catch {
-      setRegistrationMessage("팀 삭제에 실패했습니다.");
+    } catch (err) {
+      // 진행 중 해커톤이면 백엔드가 400 + data.message 로 사유를 내려줍니다.
+      const message =
+        err?.status === 400 && err?.message
+          ? err.message
+          : "팀 삭제에 실패했습니다.";
+      setToast({ type: "error", message });
       setDeleteTeamConfirmOpen(false);
     } finally {
       setIsDeletingTeam(false);
@@ -323,7 +371,7 @@ function HackathonDetailPage() {
         try {
           const [statusResult, myTeamsResult] = await Promise.allSettled([
             fetchRegistrationStatus(id),
-            fetchMyTeams(id),
+            fetchMyTeams(),
           ]);
 
           if (!isMounted) return;
@@ -354,7 +402,7 @@ function HackathonDetailPage() {
           } else {
             // eligible = not assigned to any hackathon, or assigned to this one
             const eligibleTeams = myTeams.filter(
-              t => !t.hackathonId || String(t.hackathonId) === String(id)
+              t => isTeamEligibleForHackathon(t, id, hackathonDetail?.title)
             );
             if (eligibleTeams.length === 0) {
               newTeamState = "B";
@@ -373,7 +421,6 @@ function HackathonDetailPage() {
 
           if (isMounted) {
             setTeamState(newTeamState);
-            if (newTeamState === "C2") setC2View("choice");
           }
 
           // D 상태: myTeams에 없는 경우(팀원으로 가입한 팀)도 registeredTeamId로 직접 조회
@@ -440,7 +487,13 @@ function HackathonDetailPage() {
 
   const participantTeams = remoteTeams ?? [];
   const eligibleMyTeams = myTeams.filter(
-    (team) => !team.hackathonId || String(team.hackathonId) === String(id),
+    (team) => isTeamEligibleForHackathon(team, id, hackathon?.title),
+  );
+  // 실제로 "기존 팀으로 참가" 가능한 팀: eligible + 본인이 팀장
+  const registerableMyTeams = eligibleMyTeams.filter(
+    (team) =>
+      String(team.leaderId) === String(currentUserId) ||
+      team.leader === currentUserNickname,
   );
 
   const currentLeaderId = myTeamDetail?.leaderId ?? null;
@@ -490,10 +543,13 @@ function HackathonDetailPage() {
 
   const completeRegistration = async (teamId, successMessage) => {
     const hasTeam = Boolean(teamId);
+    // 팀 생성 직후에는 myTeams에 새 팀이 아직 없으므로 먼저 갱신
+    const freshMyTeams = await fetchMyTeams();
+    setMyTeams(freshMyTeams);
     setRegistrationStatus({
       registered: true,
       teamId,
-      teamName: myTeams.find((team) => String(team.id) === String(teamId))?.name ?? null,
+      teamName: freshMyTeams.find((team) => String(team.id) === String(teamId))?.name ?? null,
     });
     // Registration is always performed by the team leader
     setTeamState(hasTeam ? "D2" : "A");
@@ -555,7 +611,6 @@ function HackathonDetailPage() {
           title: "참가 신청",
           status: "done",
           summaryDate: "2026-03-15",
-          expanded: true,
           items: [
             { date: "2026-03-15", label: "참가 신청 오픈" },
             { date: "2026-03-31", label: "참가 신청 마감" },
@@ -565,7 +620,6 @@ function HackathonDetailPage() {
           title: "해커톤 진행",
           status: "upcoming",
           summaryDate: "2026-04-01 09:00",
-          expanded: false,
           items: [
             { date: "2026-04-01 09:00", label: "오프닝 및 안내" },
             { date: "2026-04-02 18:00", label: "중간 점검" },
@@ -575,7 +629,6 @@ function HackathonDetailPage() {
           title: "마감 및 시상",
           status: "upcoming",
           summaryDate: "2026-04-03 20:00",
-          expanded: false,
           items: [
             { date: "2026-04-03 18:00", label: "최종 제출 마감" },
             { date: "2026-04-03 20:00", label: "시상 및 클로징" },
@@ -588,10 +641,37 @@ function HackathonDetailPage() {
       title: schedule.label,
       status: index === 0 ? "done" : "upcoming",
       summaryDate: schedule.at,
-      expanded: index === 0,
       items: [{ date: schedule.at.split(" ")[0], label: schedule.label }],
     }));
   }, [hackathon, id]);
+
+  // 모든 일정 항목을 시간순 단일 타임라인으로 평탄화 + done/current/upcoming 상태 계산
+  const timelineMilestones = useMemo(() => {
+    const items = scheduleSections.flatMap((section) =>
+      section.items.map((item) => ({
+        ...item,
+        sectionTitle: section.title,
+        sectionStatus: section.status,
+      })),
+    );
+    items.sort((a, b) => String(a.date).localeCompare(String(b.date)));
+
+    const now = Date.now();
+    const parsed = items.map((item) => {
+      const ts = new Date(String(item.date).replace(" ", "T")).getTime();
+      return { ...item, ts: Number.isNaN(ts) ? 0 : ts };
+    });
+
+    const firstUpcomingIdx = parsed.findIndex((item) => item.ts > now);
+    // current = 다음 예정된 항목 (없으면 마지막 = 모두 종료된 상태)
+    const currentIdx = firstUpcomingIdx === -1 ? parsed.length - 1 : firstUpcomingIdx;
+
+    return parsed.map((item, idx) => ({
+      ...item,
+      status:
+        idx < currentIdx ? "done" : idx === currentIdx ? "current" : "upcoming",
+    }));
+  }, [scheduleSections]);
 
   if (!hackathon) {
     return (
@@ -612,60 +692,12 @@ function HackathonDetailPage() {
 
   const renderTabContent = () => {
     if (activeTab === "overview") {
-      async function handleChatJoin() {
-        if (chatJoined) {
-          openChatDrawer({ hackathonId: Number(id), refreshRooms: true })
-          return
-        }
-
-        setChatJoining(true)
-        setChatJoinMessage('')
-        try {
-          await joinChat(id)
-          setChatJoined(true)
-          setChatJoinMessage('채팅방에 참가했습니다.')
-          openChatDrawer({ hackathonId: Number(id), refreshRooms: true })
-        } catch (err) {
-          if (err?.status === 409) {
-            setChatJoined(true)
-            setChatJoinMessage('이미 참가한 채팅방입니다.')
-            openChatDrawer({ hackathonId: Number(id), refreshRooms: true })
-          } else {
-            setChatJoinMessage('참가에 실패했습니다.')
-          }
-        } finally {
-          setChatJoining(false)
-        }
-      }
-
       return (
         <div className="detail-section__content">
           <section className="detail-block">
             <h2 className="detail-block__title">대회 개요</h2>
             <p className="detail-description">{hackathon.overview}</p>
           </section>
-
-          {currentUser && (
-            <section className="detail-block detail-chat-join">
-              <h2 className="detail-block__title">채팅</h2>
-              <p className="detail-description">해커톤 참가자들과 실시간으로 소통하세요.</p>
-              <div className="detail-chat-join__row">
-                <button
-                  type="button"
-                  className="team-primary-button"
-                  disabled={chatJoining}
-                  onClick={handleChatJoin}
-                >
-                  {chatJoining ? '참가 중...' : chatJoined ? '채팅방 입장하기' : '채팅 참가'}
-                </button>
-                {chatJoinMessage && (
-                  <span className={`detail-chat-join__msg${chatJoined ? ' detail-chat-join__msg--ok' : ' detail-chat-join__msg--err'}`}>
-                    {chatJoinMessage}
-                  </span>
-                )}
-              </div>
-            </section>
-          )}
 
           <section className="detail-block">
             <h2 className="detail-block__title">평가 기준</h2>
@@ -710,46 +742,33 @@ function HackathonDetailPage() {
               </div>
             </div>
 
-            <div className="schedule-stack">
-              {scheduleSections.map((section) => (
-                <article key={section.title} className="schedule-card">
-                  <div className="schedule-card__head">
-                    <div className="schedule-card__title-wrap">
-                      <span
-                        className={`schedule-card__dot schedule-card__dot--${section.status}`}
-                      />
-                      <strong className="schedule-card__title">
-                        {section.title}
-                      </strong>
-                    </div>
-                    <div className="schedule-card__summary">
-                      <span>{section.summaryDate}</span>
-                      <span className="schedule-card__chevron">
-                        {section.expanded ? "▲" : "▼"}
+            <ol className="schedule-timeline">
+              {timelineMilestones.map((item, idx) => (
+                <li
+                  key={`${item.sectionTitle}-${item.label}-${idx}`}
+                  className={`schedule-timeline__item schedule-timeline__item--${item.status}`}
+                  aria-current={item.status === "current" ? "step" : undefined}
+                >
+                  <div className="schedule-timeline__marker">
+                    <span className="schedule-timeline__dot" aria-hidden="true">
+                      {item.status === "done" ? <Check size={12} strokeWidth={3} /> : null}
+                    </span>
+                  </div>
+                  <div className="schedule-timeline__content">
+                    <div className="schedule-timeline__head">
+                      <span className="schedule-timeline__date">{item.date}</span>
+                      <span className="schedule-timeline__section">
+                        {item.sectionTitle}
                       </span>
                     </div>
+                    <p className="schedule-timeline__label">{item.label}</p>
+                    {item.status === "current" && (
+                      <span className="schedule-timeline__pill">현재</span>
+                    )}
                   </div>
-
-                  {section.expanded && (
-                    <div className="schedule-card__body">
-                      {section.items.map((item) => (
-                        <div
-                          key={`${section.title}-${item.label}`}
-                          className="schedule-card__item"
-                        >
-                          <span className="schedule-card__item-date">
-                            {item.date}
-                          </span>
-                          <span className="schedule-card__item-label">
-                            {item.label}
-                          </span>
-                        </div>
-                      ))}
-                    </div>
-                  )}
-                </article>
+                </li>
               ))}
-            </div>
+            </ol>
           </section>
         </div>
       );
@@ -782,14 +801,6 @@ function HackathonDetailPage() {
     }
 
     if (activeTab === "team") {
-      const eligibleTeams = myTeams.filter(
-        t => !t.hackathonId || String(t.hackathonId) === String(id)
-      );
-
-      const isTeamLeader = (team) =>
-        String(team.leaderId) === String(currentUser?.userId) ||
-        team.leader === currentUser?.nickname;
-
       const renderParticipantTable = (highlightMyTeam) => (
         <div className="participant-team-table">
           <div className="participant-team-table__head">
@@ -827,196 +838,43 @@ function HackathonDetailPage() {
 
       return (
         <div className="stack-list team-tab-layout">
-          {/* A: 팀 없음 */}
-          {teamState === "A" && (
-            <div className="team-state-card team-state-card--locked">
-              <div className="team-state-card__icon"><Users size={36} strokeWidth={1.5} /></div>
-              <h2 className="team-state-card__title">팀이 없어요</h2>
-              <p className="team-state-card__description">
-                팀을 만들거나 합류한 뒤 해커톤에 신청할 수 있어요.
-              </p>
-              <div className="team-state-actions">
-                <button type="button" className="team-primary-button" onClick={() => openTeamCreateModal(true)}>
-                  팀 만들기
-                </button>
-                <button type="button" className="team-secondary-button" onClick={() => navigate(`/camp?hackathon=${hackathon?.slug ?? ""}`)}>
-                  팀 합류하기
-                </button>
-              </div>
-            </div>
-          )}
-
-          {/* B: 모든 팀이 다른 해커톤에 참가 중 */}
-          {teamState === "B" && (
-            <section className="my-team-panel">
-              <div className="team-state-warning">
-                <span className="team-state-warning__icon"><AlertTriangle size={18} /></span>
-                <div>
-                  <p className="team-state-warning__title">참가 가능한 팀이 없어요.</p>
-                  <p className="team-state-warning__desc">내 모든 팀이 이미 다른 해커톤에 참가 중이에요.</p>
-                </div>
-              </div>
-              <div className="my-team-panel__section">
-                <p className="my-team-panel__label">내 팀 목록</p>
-                <div className="participant-team-table">
-                  <div className="participant-team-table__head">
-                    <span>팀명</span>
-                    <span>참가 중인 해커톤</span>
-                    <span>역할</span>
-                  </div>
-                  {myTeams.map((team) => (
-                    <div key={team.id} className="participant-team-table__row">
-                      <div className="participant-team-table__team"><strong>{team.name}</strong></div>
-                      <span className="meta-text">{team.hackathonName ?? "-"}</span>
-                      <span>
-                        <span className={`team-role-badge${isTeamLeader(team) ? "" : " team-role-badge--member"}`}>
-                          {isTeamLeader(team) ? "팀장" : "팀원"}
-                        </span>
-                      </span>
-                    </div>
-                  ))}
-                </div>
-              </div>
-              <div className="my-team-panel__actions">
-                <button
-                  type="button"
-                  className="team-secondary-button"
-                  onClick={() => openTeamCreateModal(true)}
-                >
-                  + 새 팀 만들어서 신청하기
-                </button>
-              </div>
-            </section>
-          )}
-
-          {/* C-1: 신청 가능한 팀 있음 / 팀장인 팀 없음 */}
-          {teamState === "C1" && (
-            <section className="my-team-panel">
-              <div className="team-state-warning team-state-warning--info">
-                <span className="team-state-warning__icon"><Info size={18} /></span>
-                <div>
-                  <p className="team-state-warning__title">팀장이 신청해야 해커톤에 참가할 수 있어요.</p>
-                  <p className="team-state-warning__desc">팀장에게 이 해커톤 신청을 요청해보세요.</p>
-                </div>
-              </div>
-              <div className="my-team-panel__section">
-                <p className="my-team-panel__label">내 팀 목록</p>
-                <div className="participant-team-table">
-                  <div className="participant-team-table__head">
-                    <span>팀명</span>
-                    <span>역할</span>
-                    <span>상태</span>
-                  </div>
-                  {eligibleTeams.map((team) => (
-                    <div key={team.id} className="participant-team-table__row">
-                      <div className="participant-team-table__team"><strong>{team.name}</strong></div>
-                      <span><span className="team-role-badge team-role-badge--member">팀원</span></span>
-                      <span className="meta-text">미신청</span>
-                    </div>
-                  ))}
-                </div>
-              </div>
-              <div className="my-team-panel__actions">
-                <button
-                  type="button"
-                  className="team-secondary-button"
-                  onClick={() => openTeamCreateModal(true)}
-                >
-                  + 새 팀 만들어서 신청하기
-                </button>
-              </div>
-            </section>
-          )}
-
-          {/* C-2: 신청 가능한 팀 있음 / 팀장인 팀 있음 */}
-          {teamState === "C2" && c2View === "choice" && (
+          {/* A/B/C1/C2 통합 초기 화면: 항상 3개 버튼 노출 */}
+          {(teamState === "A" || teamState === "B" || teamState === "C1" || teamState === "C2") && (
             <div className="team-state-card">
               <div className="team-state-card__icon"><Trophy size={36} strokeWidth={1.5} /></div>
-              <h2 className="team-state-card__title">어떻게 참가하시겠어요?</h2>
-              <p className="team-state-card__description">
+              <p className="team-state-card__description team-state-card__description--lg">
                 기존 팀으로 바로 신청하거나, 새로운 팀을 만들어 참가할 수 있어요.
               </p>
               <div className="team-state-actions">
                 <button
                   type="button"
                   className="team-primary-button"
-                  onClick={() => setC2View("select")}
+                  onClick={() => {
+                    setExistingTeamMessage("");
+                    setSelectedExistingTeamId(
+                      registerableMyTeams.length > 0 ? String(registerableMyTeams[0].id) : "",
+                    );
+                    setIsExistingTeamSelectOpen(true);
+                  }}
                 >
                   기존 팀으로 참가
                 </button>
                 <button
                   type="button"
                   className="team-secondary-button"
-                  onClick={() => openTeamCreateModal(false)}
+                  onClick={() => openTeamCreateModal(true)}
                 >
                   새로운 팀 생성
                 </button>
+                <button
+                  type="button"
+                  className="team-secondary-button"
+                  onClick={() => navigate(`/camp?hackathon=${hackathon?.slug ?? ""}`)}
+                >
+                  팀원 모집 보러가기
+                </button>
               </div>
             </div>
-          )}
-
-          {teamState === "C2" && c2View === "select" && (
-            <section className="my-team-panel">
-              <div className="my-team-panel__header">
-                <h2 className="my-team-panel__title">어떤 팀으로 신청할까요?</h2>
-              </div>
-              <div className="my-team-panel__section">
-                <div className="team-select-list">
-                  {myTeams.map((team) => {
-                    const leader = isTeamLeader(team);
-                    const elsewhere = team.hackathonId && String(team.hackathonId) !== String(id);
-                    const selectable = leader && !elsewhere;
-                    return (
-                      <label
-                        key={team.id}
-                        className={`team-select-item${String(selectedTeamForRegistration) === String(team.id) ? " team-select-item--active" : ""}${!selectable ? " team-select-item--disabled" : ""}`}
-                      >
-                        <input
-                          type="radio"
-                          name="teamForRegistration"
-                          value={team.id}
-                          disabled={!selectable}
-                          checked={String(selectedTeamForRegistration) === String(team.id)}
-                          onChange={() => selectable && setSelectedTeamForRegistration(String(team.id))}
-                        />
-                        <div className="team-select-item__body">
-                          <div className="team-select-item__title-row">
-                            <strong>{team.name}</strong>
-                            <span className={`team-role-badge${!leader ? " team-role-badge--member" : ""}`}>
-                              {leader ? "팀장" : "팀원"}
-                            </span>
-                            {!selectable && (
-                              <span className="meta-text">
-                                {!leader ? "선택 불가 · 팀원" : `선택 불가 · ${team.hackathonName ?? "다른 해커톤"} 참가 중`}
-                              </span>
-                            )}
-                          </div>
-                          <p className="meta-text">팀원 {team.currentMembers}/{team.maxMembers}명</p>
-                        </div>
-                      </label>
-                    );
-                  })}
-                </div>
-              </div>
-              <div className="my-team-panel__actions my-team-panel__actions--spread">
-                <button
-                  type="button"
-                  className="team-primary-button"
-                  disabled={!selectedTeamForRegistration || registerHereLoading}
-                  onClick={() => setRegisterConfirmOpen(true)}
-                >
-                  {registerHereLoading ? "신청 중..." : "이 팀으로 신청하기"}
-                </button>
-                <button
-                  type="button"
-                  className="button-link button-link--ghost"
-                  onClick={() => setC2View("choice")}
-                >
-                  ← 돌아가기
-                </button>
-              </div>
-              {registrationMessage && <p className="meta-text">{registrationMessage}</p>}
-            </section>
           )}
 
           {/* D-1: 신청 완료 / 팀원 */}
@@ -1110,6 +968,12 @@ function HackathonDetailPage() {
                     type="button"
                     className="team-danger-button"
                     onClick={() => setDeleteTeamConfirmOpen(true)}
+                    disabled={isHackathonDeletionBlocked(hackathon?.status)}
+                    title={
+                      isHackathonDeletionBlocked(hackathon?.status)
+                        ? "진행 중인 해커톤의 팀은 삭제할 수 없습니다."
+                        : undefined
+                    }
                   >
                     팀 삭제
                   </button>
@@ -1416,6 +1280,39 @@ function HackathonDetailPage() {
               <span>대상</span>
             </div>
           </div>
+
+          {currentUser && (
+            <div className="sidebar-card sidebar-card--chat">
+              <div className="sidebar-chat__head">
+                <span className="sidebar-chat__icon">
+                  <MessageCircle size={18} strokeWidth={2} />
+                </span>
+                <div>
+                  <h3>채팅방</h3>
+                  <p className="sidebar-chat__desc">참가자들과 실시간으로 소통하세요</p>
+                </div>
+              </div>
+              <button
+                type="button"
+                className="team-primary-button team-primary-button--small sidebar-chat__btn"
+                disabled={chatJoining}
+                onClick={handleChatJoin}
+              >
+                {chatJoining
+                  ? "참가 중..."
+                  : chatJoined
+                    ? "채팅방 입장하기"
+                    : "채팅방 참가하기"}
+              </button>
+              {chatJoinMessage ? (
+                <p
+                  className={`sidebar-chat__msg${chatJoined ? " sidebar-chat__msg--ok" : " sidebar-chat__msg--err"}`}
+                >
+                  {chatJoinMessage}
+                </p>
+              ) : null}
+            </div>
+          )}
         </aside>
       </div>
 
@@ -1521,82 +1418,141 @@ function HackathonDetailPage() {
           onClick={() => setIsExistingTeamSelectOpen(false)}
         >
           <div
-            className="team-notice-modal"
+            className="team-select-modal"
             role="dialog"
             aria-modal="true"
             aria-labelledby="existing-team-select-title"
             onClick={(event) => event.stopPropagation()}
           >
-            <h2 id="existing-team-select-title">기존 팀으로 참가</h2>
-            {eligibleMyTeams.length === 0 ? (
-              <>
-                <p className="team-notice-copy team-notice-copy--compact">
-                  현재 이 해커톤에 연결할 수 있는 내 팀이 없습니다.
+            <header className="team-select-modal__header">
+              <div className="team-select-modal__heading">
+                <p className="eyebrow">join hackathon</p>
+                <h2 id="existing-team-select-title">기존 팀으로 참가하기</h2>
+                <p className="team-select-modal__subtitle">
+                  내가 팀장인 팀 중 이 해커톤에 참가할 팀을 선택해주세요.
                 </p>
-                <p className="team-notice-copy team-notice-copy--compact">
-                  먼저 팀원 모집 페이지에서 새 팀을 생성한 뒤 다시 시도해주세요.
-                </p>
-              </>
-            ) : (
-              <div className="team-select-list">
-                {eligibleMyTeams.map((team) => (
-                  <label
-                    key={team.id}
-                    className={`team-select-item${
-                      String(selectedExistingTeamId) === String(team.id)
-                        ? " team-select-item--active"
-                        : ""
-                    }`}
-                  >
-                    <input
-                      type="radio"
-                      name="existingTeam"
-                      value={team.id}
-                      checked={String(selectedExistingTeamId) === String(team.id)}
-                      onChange={() => setSelectedExistingTeamId(String(team.id))}
-                    />
-                    <div className="team-select-item__body">
-                      <div className="team-select-item__title-row">
-                        <strong>{team.name}</strong>
-                        <span className="team-role-badge">
-                          {team.hackathonId ? "연결된 팀" : "독립 팀"}
-                        </span>
-                      </div>
-                      <p className="meta-text">
-                        팀장 {team.leader} · 팀원 {team.currentMembers}/{team.maxMembers}명
-                      </p>
-                      {team.hackathonName ? (
-                        <p className="meta-text">
-                          현재 해커톤: {team.hackathonName}
-                        </p>
-                      ) : null}
-                    </div>
-                  </label>
-                ))}
               </div>
-            )}
-            {existingTeamMessage ? (
-              <p className="team-notice-copy team-notice-copy--compact team-notice-copy--error">
-                {existingTeamMessage}
-              </p>
-            ) : null}
-            <div className="team-notice-actions">
               <button
                 type="button"
-                className="team-secondary-button team-secondary-button--muted"
+                className="team-select-modal__close"
+                aria-label="닫기"
                 onClick={() => setIsExistingTeamSelectOpen(false)}
               >
-                닫기
+                <X size={20} />
               </button>
-              <button
-                type="button"
-                className="team-primary-button"
-                disabled={eligibleMyTeams.length === 0 || isRegisteringExistingTeam}
-                onClick={handleExistingTeamRegister}
-              >
-                {isRegisteringExistingTeam ? "참가 처리 중..." : "선택한 팀으로 참가"}
-              </button>
+            </header>
+
+            <div className="team-select-modal__body">
+              {registerableMyTeams.length === 0 ? (
+                <div className="team-select-empty">
+                  <div className="team-select-empty__icon">
+                    <Users size={36} strokeWidth={1.5} />
+                  </div>
+                  <h3 className="team-select-empty__title">
+                    참가할 수 있는 팀이 없어요
+                  </h3>
+                  <p className="team-select-empty__desc">
+                    모든 해커톤에 참가중이거나, 팀이 없습니다.
+                  </p>
+                  <div className="team-select-empty__actions">
+                    <button
+                      type="button"
+                      className="team-primary-button"
+                      onClick={() => {
+                        setIsExistingTeamSelectOpen(false);
+                        openTeamCreateModal(true);
+                      }}
+                    >
+                      새 팀 만들기
+                    </button>
+                    <button
+                      type="button"
+                      className="team-secondary-button"
+                      onClick={() => {
+                        setIsExistingTeamSelectOpen(false);
+                        navigate(`/camp?hackathon=${hackathon?.slug ?? ""}`);
+                      }}
+                    >
+                      팀원 모집 보러가기
+                    </button>
+                  </div>
+                </div>
+              ) : (
+                <div className="team-select-list">
+                  {registerableMyTeams.map((team) => {
+                    const isActive = String(selectedExistingTeamId) === String(team.id);
+                    return (
+                      <label
+                        key={team.id}
+                        className={`team-select-card${isActive ? " team-select-card--active" : ""}`}
+                      >
+                        <input
+                          type="radio"
+                          name="existingTeam"
+                          value={team.id}
+                          checked={isActive}
+                          onChange={() => setSelectedExistingTeamId(String(team.id))}
+                        />
+                        <div className="team-select-card__body">
+                          <div className="team-select-card__head">
+                            <strong className="team-select-card__name">{team.name}</strong>
+                            <span className="team-role-badge team-role-badge--leader">
+                              팀장
+                            </span>
+                          </div>
+                          {team.description ? (
+                            <p className="team-select-card__desc">{team.description}</p>
+                          ) : null}
+                          <div className="team-select-card__meta">
+                            <span className="team-select-card__count">
+                              <Users size={14} strokeWidth={2} />
+                              {team.currentMembers}/{team.maxMembers}명
+                            </span>
+                            {(team.positionDetails ?? []).slice(0, 4).map((pos) => (
+                              <span key={pos.positionName} className="tag-chip">
+                                {pos.positionName}
+                              </span>
+                            ))}
+                            {team.positionDetails?.length > 4 ? (
+                              <span className="tag-chip tag-chip--ghost">
+                                +{team.positionDetails.length - 4}
+                              </span>
+                            ) : null}
+                          </div>
+                        </div>
+                        <span className="team-select-card__check" aria-hidden="true">
+                          {isActive ? <Check size={18} strokeWidth={3} /> : null}
+                        </span>
+                      </label>
+                    );
+                  })}
+                </div>
+              )}
+
+              {existingTeamMessage ? (
+                <p className="team-select-modal__error">{existingTeamMessage}</p>
+              ) : null}
             </div>
+
+            {registerableMyTeams.length > 0 && (
+              <footer className="team-select-modal__footer">
+                <button
+                  type="button"
+                  className="team-secondary-button team-secondary-button--muted"
+                  onClick={() => setIsExistingTeamSelectOpen(false)}
+                >
+                  취소
+                </button>
+                <button
+                  type="button"
+                  className="team-primary-button"
+                  disabled={isRegisteringExistingTeam || !selectedExistingTeamId}
+                  onClick={handleExistingTeamRegister}
+                >
+                  {isRegisteringExistingTeam ? "참가 처리 중..." : "선택한 팀으로 참가"}
+                </button>
+              </footer>
+            )}
           </div>
         </div>
       )}
@@ -2204,6 +2160,8 @@ function HackathonDetailPage() {
           </aside>
         </div>
       )}
+
+      <Toast toast={toast} onDismiss={() => setToast(null)} />
     </section>
   );
 }

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -7,9 +7,12 @@ import {
   fetchTeamDetail,
   fetchTeamApplications,
   decideTeamApplication,
+  deleteTeam,
+  isHackathonDeletionBlocked,
   updateTeam,
 } from '../api/teams.js'
 import { getStoredUser, SESSION_EXPIRED_EVENT } from '../lib/auth.js'
+import Toast from '../components/common/Toast.jsx'
 
 function ApplicationsModal({ team, onClose, onUpdate }) {
   const [applications, setApplications] = useState([])
@@ -116,7 +119,7 @@ const CONTACT_TYPES = [
   { value: 'EMAIL', label: '이메일' },
 ]
 
-function EditTeamModal({ team, onClose, onSaved }) {
+function EditTeamModal({ team, onClose, onSaved, onDeleted }) {
   const [form, setForm] = useState({
     name: team.name,
     description: team.description ?? '',
@@ -130,6 +133,9 @@ function EditTeamModal({ team, onClose, onSaved }) {
   })
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState(null)
+  const [confirmDelete, setConfirmDelete] = useState(false)
+  const [deleting, setDeleting] = useState(false)
+  const deleteBlocked = isHackathonDeletionBlocked(team.hackathonStatus)
 
   function addPosition() {
     setForm((f) => ({ ...f, positions: [...f.positions, { positionName: '', requiredCount: '1' }] }))
@@ -149,6 +155,27 @@ function EditTeamModal({ team, onClose, onSaved }) {
       ...f,
       positions: f.positions.map((p, i) => i === index ? { ...p, [field]: value } : p),
     }))
+  }
+
+  async function handleDelete() {
+    setDeleting(true)
+    setError(null)
+    try {
+      await deleteTeam(team.id)
+      setConfirmDelete(false)
+      onDeleted?.({ type: 'success', message: '팀이 삭제되었습니다.' })
+      onClose()
+    } catch (err) {
+      // 진행 중 해커톤이면 백엔드가 400 + data.message 로 사유를 내려줍니다.
+      const message =
+        err?.status === 400 && err?.message
+          ? err.message
+          : '팀 삭제에 실패했습니다.'
+      setConfirmDelete(false)
+      onDeleted?.({ type: 'error', message })
+    } finally {
+      setDeleting(false)
+    }
   }
 
   async function handleSave() {
@@ -302,18 +329,67 @@ function EditTeamModal({ team, onClose, onSaved }) {
           {error && <p className="mypage-modal__error">{error}</p>}
         </div>
 
-        <div className="mypage-modal__footer">
-          <button type="button" className="team-secondary-button" onClick={onClose}>취소</button>
+        <div className="mypage-modal__footer mypage-modal__footer--spread">
           <button
             type="button"
-            className="team-primary-button"
-            disabled={saving || !form.name.trim()}
-            onClick={handleSave}
+            className="team-danger-button"
+            disabled={deleting || deleteBlocked}
+            title={deleteBlocked ? '진행 중인 해커톤의 팀은 삭제할 수 없습니다.' : undefined}
+            onClick={() => setConfirmDelete(true)}
           >
-            {saving ? '저장 중...' : '저장'}
+            팀 삭제
           </button>
+          <div className="mypage-modal__footer-actions">
+            <button type="button" className="team-secondary-button" onClick={onClose}>취소</button>
+            <button
+              type="button"
+              className="team-primary-button"
+              disabled={saving || !form.name.trim()}
+              onClick={handleSave}
+            >
+              {saving ? '저장 중...' : '저장'}
+            </button>
+          </div>
         </div>
       </div>
+
+      {confirmDelete && (
+        <div
+          className="modal-backdrop"
+          role="presentation"
+          onClick={() => !deleting && setConfirmDelete(false)}
+        >
+          <div
+            className="team-notice-modal"
+            role="dialog"
+            aria-modal="true"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h2>팀을 삭제할까요?</h2>
+            <p className="team-notice-copy">
+              팀을 삭제하면 팀원 전체의 해커톤 참가가 취소돼요. 정말 삭제하시겠어요?
+            </p>
+            <div className="team-notice-actions">
+              <button
+                type="button"
+                className="team-secondary-button team-secondary-button--muted"
+                disabled={deleting}
+                onClick={() => setConfirmDelete(false)}
+              >
+                취소
+              </button>
+              <button
+                type="button"
+                className="team-danger-button"
+                disabled={deleting}
+                onClick={handleDelete}
+              >
+                {deleting ? '삭제 중...' : '삭제'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   )
 }
@@ -561,6 +637,7 @@ function MyPage() {
   const [applicationCounts, setApplicationCounts] = useState({})
   const [applicationsModal, setApplicationsModal] = useState(null)
   const [infoModal, setInfoModal] = useState(null)
+  const [toast, setToast] = useState(null)
   const [editTeamModal, setEditTeamModal] = useState(null)
   const [profileEditOpen, setProfileEditOpen] = useState(false)
   const [userTagObjects, setUserTagObjects] = useState([]) // { tagId, name }[]
@@ -751,23 +828,28 @@ function MyPage() {
             ) : (
               myTeams.map((team) => {
                 const isLeader = Number(team.leaderId) === Number(user?.userId)
+                const isDeleted = team.isDeleted
                 return (
                   <article
                     key={team.id}
-                    className={`mypage-team-item${isLeader ? ' mypage-team-item--primary' : ''}`}
+                    className={`mypage-team-item${isLeader ? ' mypage-team-item--primary' : ''}${isDeleted ? ' mypage-team-item--deleted' : ''}`}
+                    aria-disabled={isDeleted || undefined}
                   >
                     <div className="mypage-team-item__col mypage-team-item__col--name">
                       <span className={`mypage-role-badge${isLeader ? ' mypage-role-badge--leader' : ''}`}>
                         {isLeader ? '팀장' : '팀원'}
                       </span>
                       <h3>{team.name}</h3>
+                      {isDeleted && (
+                        <span className="mypage-deleted-badge">삭제됨</span>
+                      )}
                     </div>
                     <div className="mypage-team-item__col mypage-team-item__col--hackathon">
                       <p>{team.hackathonName}</p>
                       <span>{team.currentMembers} / {team.maxMembers}명</span>
                     </div>
                     <div className="mypage-team-item__col mypage-team-item__col--actions">
-                      {isLeader && (
+                      {isLeader && !isDeleted && (
                         <>
                           <button
                             type="button"
@@ -785,13 +867,15 @@ function MyPage() {
                           </button>
                         </>
                       )}
-                      <button
-                        type="button"
-                        className="team-secondary-button team-secondary-button--muted"
-                        onClick={() => setInfoModal(team)}
-                      >
-                        팀 정보
-                      </button>
+                      {!isDeleted && (
+                        <button
+                          type="button"
+                          className="team-secondary-button team-secondary-button--muted"
+                          onClick={() => setInfoModal(team)}
+                        >
+                          팀 정보
+                        </button>
+                      )}
                     </div>
                   </article>
                 )
@@ -819,9 +903,14 @@ function MyPage() {
                 const status = team.hackathonStatus
                 const isDone = status === 'ended'
                 const isActive = status === 'closed'
+                const isDeleted = team.isDeleted
 
                 return (
-                  <div key={team.id} className="mypage-timeline-item">
+                  <div
+                    key={team.id}
+                    className={`mypage-timeline-item${isDeleted ? ' mypage-timeline-item--deleted' : ''}`}
+                    aria-disabled={isDeleted || undefined}
+                  >
                     <div className="mypage-timeline-item__line">
                       <div className={`mypage-timeline-item__dot${isDone ? ' mypage-timeline-item__dot--done' : isActive ? ' mypage-timeline-item__dot--active' : ''}`} />
                     </div>
@@ -831,6 +920,9 @@ function MyPage() {
                         <span className={`mypage-timeline-badge mypage-timeline-badge--${status ?? 'closed'}`}>
                           {isDone ? '완료' : isActive ? '심사 중' : status === 'open' ? '모집 중' : team.hackathonStatusLabel ?? '오픈 예정'}
                         </span>
+                        {isDeleted && (
+                          <span className="mypage-deleted-badge">삭제됨</span>
+                        )}
                       </div>
                       <p className="mypage-timeline-item__team">{team.name}</p>
                       <div className="mypage-timeline-item__meta">
@@ -877,6 +969,12 @@ function MyPage() {
           team={editTeamModal}
           onClose={() => setEditTeamModal(null)}
           onSaved={() => loadTeams(user)}
+          onDeleted={(nextToast) => {
+            setToast(nextToast)
+            if (nextToast?.type === 'success') {
+              loadTeams(user)
+            }
+          }}
         />
       )}
 
@@ -892,6 +990,8 @@ function MyPage() {
           }}
         />
       )}
+
+      <Toast toast={toast} onDismiss={() => setToast(null)} />
     </section>
   )
 }


### PR DESCRIPTION
## Summary

해커톤 상세 팀 탭의 상태 머신/UX를 정리하고, 새 팀 삭제 정책을 프론트에 반영했습니다. 일정 탭은 단일 타임라인으로 재구성하고 현재 단계에 펄스 애니메이션을 적용했습니다.

### 팀 삭제 정책 (백엔드 변경 대응)
- 진행 중(`closed`) 해커톤 팀: 삭제 버튼 disabled, 400 응답 시 \`data.message\` 토스트로 노출
- 종료(`ended`) 해커톤 팀: 소프트 딜리트 (상세 조회 404)
- 그 외(`upcoming`/`open`): 하드 딜리트
- \`isDeleted\` 플래그를 \`normalizeTeam\`에 추가하고, 마이페이지/참가이력 카드에서 "삭제됨" 뱃지 + 클릭 비활성화
- 공통 \`Toast\` 컴포넌트 신설(\`components/common/Toast.jsx\`), HackathonDetailPage / CampPage / MyPage 적용

### 마이페이지
- EditTeamModal에 팀 삭제 버튼 + 확인 다이얼로그 추가 (팀장만, 진행 중이면 disabled)
- 삭제 성공/실패 토스트 처리

### 해커톤 상세 팀 탭
- 상태 머신 정리: \`fetchMyTeams()\` 전체 조회로 변경 후 \`hackathonName\` 폴백 필터 (\`/teams/me\`가 \`hackathonId\`를 반환하지 않는 이슈 회피)
- 팀 생성 후 D2 자동 전환: 백엔드가 \`POST /teams\`에서 자동 등록까지 처리하므로 \`registerHackathon\` 중복 호출 제거(409 회피)
- A/B/C1/C2 초기 화면 통합: "기존 팀으로 참가 / 새로운 팀 생성 / 팀원 모집 보러가기" 3버튼 단일 카드
- 기존 팀 선택 모달 디자인 개선: 헤더/본문/푸터 분리, 팀 카드 포맷, 빈 상태 CTA(새 팀 만들기 / 팀원 모집)
- 채팅 참가 섹션을 overview 탭에서 사이드바 카드로 이동

### 일정 탭
- 섹션별 collapsible 카드 → 단일 타임라인으로 재구성
- 모든 항목 시간순 평탄화 + done/current/upcoming 자동 분류
- 현재 단계: 도트 펄스 애니메이션 + "현재" pill fade 애니메이션
- done 항목은 라벨에 취소선

### 기타
- \`detail-section__content\` 블록 간 32px gap + 가로 구분선으로 시각 구분 강화

## Test plan
- [ ] 팀 삭제: 진행 중/종료/예정 해커톤별 동작 확인 (버튼 disabled / 토스트 / 소프트·하드 삭제)
- [ ] 마이페이지 EditTeamModal에서 삭제 → 목록 갱신 + 토스트
- [ ] 마이페이지 참가이력에서 삭제된 팀 카드 비활성화 표시
- [ ] devking으로 그린테크 해커톤 → 새 팀 생성 → 새로고침 없이 D2 전환 확인
- [ ] 통합 초기 화면 3버튼 동작 (기존 팀 / 새 팀 / 팀원 모집)
- [ ] 기존 팀 모달: 빈 상태 + CTA, 팀 선택 + 참가 처리
- [ ] 일정 탭 타임라인: 현재 단계 펄스 애니메이션 확인
- [ ] 채팅 사이드바 카드: 참가 → 입장하기 토글

🤖 Generated with [Claude Code](https://claude.com/claude-code)